### PR TITLE
Update ID1A3.json

### DIFF
--- a/web/schemas/ID1A3.json
+++ b/web/schemas/ID1A3.json
@@ -493,6 +493,15 @@
             "Yb",
             "other"
         ]
+    },
+    {
+        "key": "BeamlineSetupDocument",
+        "type": "string",
+        "optional": true,
+        "multiple": false,
+        "section": "Beam",
+        "description": "Beamline setup document location",
+        "placeholder": "/"
     },    
     {
         "key": "Detectors",
@@ -518,15 +527,6 @@
             "CanberraSingleElement",
             "CanberraMultielement"
         ]
-    },
-    {
-        "key": "BeamlineSetupDocument",
-        "type": "string",
-        "optional": true,
-        "multiple": false,
-        "section": "Beam",
-        "description": "Beamline setup document location",
-        "placeholder": "/"
     },    
     {
         "key": "ExperimentType",

--- a/web/schemas/ID3A.json
+++ b/web/schemas/ID3A.json
@@ -432,6 +432,15 @@
         ]
     },
     {
+        "key": "BeamlineSetupDocument",
+        "type": "string",
+        "optional": true,
+        "multiple": false,
+        "section": "Beam",
+        "description": "Beamline setup document location",
+        "placeholder": "/"
+    },       
+    {
         "key": "Detectors",
         "type": "list_str",
         "optional": false,
@@ -458,16 +467,7 @@
             "Pilatus100K",
             "Others"
         ]
-    },
-    {
-        "key": "BeamlineSetupDocument",
-        "type": "string",
-        "optional": true,
-        "multiple": false,
-        "section": "Beam",
-        "description": "Beamline setup document location",
-        "placeholder": "/"
-    },    
+    }, 
     {
         "key": "ExperimentType",
         "type": "list_str",


### PR DESCRIPTION
@vkuznet 

Cleanup: BeamlineSetupDocument key moved in front of Detectors key. This was done to keep all keys for Beam section together. It was out of place before.